### PR TITLE
fixing bug from "add automatic host attachment" commit

### DIFF
--- a/freeipa/client/init.sls
+++ b/freeipa/client/init.sls
@@ -7,7 +7,7 @@ include:
 - freeipa.client.cert
 
 {%- if client.install_principal is defined %}
-{% set otp = salt['random.get_str'](20) %}
+{%- set otp = salt['random.get_str'](20) %}
 
 freeipa_push_principal:
   file.managed:
@@ -60,13 +60,7 @@ freeipa_host_add:
       - cmd: freeipa_client_install
     - onchanges:
       - file: freeipa_push_principal
-{%- endif %}
 
-{%- if client.get('enabled', False) %}
-
-freeipa_client_pkgs:
-  pkg.installed:
-    - names: {{ client.pkgs }}
 freeipa_cleanup_cookiejar:
   file.absent:
     - name: /tmp/cookiejar
@@ -94,6 +88,13 @@ freeipa_kdestroy:
       -cmd: freeipa_client_install
     - onchanges:
       - file: freeipa_push_principal
+{%- endif %}
+
+{%- if client.get('enabled', False) %}
+
+freeipa_client_pkgs:
+  pkg.installed:
+    - names: {{ client.pkgs }}
 
 freeipa_client_install:
   cmd.run:


### PR DESCRIPTION
At the moment, when client.install_principal is undefined there are three states that break due to their requisites not being included in the run:

          ID: freeipa_cleanup_cookiejar
    Function: file.absent
        Name: /tmp/cookiejar
      Result: False
     Comment: The following requisites were not found:
                                 onchanges:
                                     cmd: freeipa_host_add
                                 require:
                                     cmd: freeipa_host_add

          ID: freeipa_cleanup_keytab
    Function: file.absent
        Name: /tmp/principal.keytab
      Result: False
     Comment: The following requisites were not found:
                                 onchanges:
                                     cmd: freeipa_host_add
                                 require:
                                     cmd: freeipa_host_add

          ID: freeipa_kdestroy
    Function: cmd.run
        Name: kdestroy
      Result: False
     Comment: The following requisites were not found:
                                 onchanges:
                                     file: freeipa_push_principal
                                 require:
                                     cmd: freeipa_host_add

This PR will fix this by moving those states into the "if client.install_principal is defined" block. 