### PR TITLE
Send credentials via environment variables.  Support DNS forwarders without DNSSEC.  Support latest version of BIND.

### DIFF
--- a/freeipa/client/init.sls
+++ b/freeipa/client/init.sls
@@ -67,7 +67,7 @@ freeipa_cleanup_cookiejar:
     - require:
       - cmd: freeipa_host_add
     - require_in:
-      -cmd: freeipa_client_install
+      - cmd: freeipa_client_install
     - onchanges:
       - cmd: freeipa_host_add
 freeipa_cleanup_keytab:
@@ -76,7 +76,7 @@ freeipa_cleanup_keytab:
     - require:
       - cmd: freeipa_host_add
     - require_in:
-      -cmd: freeipa_client_install
+      - cmd: freeipa_client_install
     - onchanges:
       - cmd: freeipa_host_add
 freeipa_kdestroy:
@@ -85,7 +85,7 @@ freeipa_kdestroy:
     - require:
       - cmd: freeipa_host_add
     - require_in:
-      -cmd: freeipa_client_install
+      - cmd: freeipa_client_install
     - onchanges:
       - file: freeipa_push_principal
 {%- endif %}

--- a/freeipa/common.sls
+++ b/freeipa/common.sls
@@ -1,13 +1,18 @@
 {%- from "freeipa/map.jinja" import client,server with context %}
+{%- set openssh_server_enabled = salt.pillar.get('openssh:server:enabled', False) %}
 
+{%- if openssh_server_enabled %}
 include:
 - openssh.server
+{%- endif %}
 
 sssd_service:
   service.running:
     - name: sssd
+    {%- if openssh_server_enabled %}
     - watch_in:
       - service: openssh_server_service
+    {%- endif %}
     - watch:
       - file: sssd_conf
 
@@ -68,4 +73,3 @@ pam_auth_update:
       - file: pam_mkhomedir_config
 {%- endif %}
 {%- endif %}
-

--- a/freeipa/files/krb5.conf
+++ b/freeipa/files/krb5.conf
@@ -1,5 +1,13 @@
-{%- from "freeipa/map.jinja" import client, ipa_servers with context -%}
+{%- from "freeipa/map.jinja" import client, server, ipa_servers with context -%}
 includedir /var/lib/sss/pubconf/krb5.include.d/
+{%- if server.get('enabled', False) %}
+includedir /etc/krb5.conf.d/
+
+[logging]
+  default = FILE:/var/log/krb5libs.log
+  kdc = FILE:/var/log/krb5kdc.log
+  admin_server = FILE:/var/log/kadmind.log
+{%- endif %}
 
 [libdefaults]
   default_realm = {{ client.realm }}
@@ -8,6 +16,8 @@ includedir /var/lib/sss/pubconf/krb5.include.d/
   rdns = false
   ticket_lifetime = 24h
   forwardable = yes
+  udp_preference_limit = 0
+  default_ccache_name = KEYRING:persistent:%{uid}
 
 [realms]
   {{ client.realm }} = {
@@ -18,17 +28,18 @@ includedir /var/lib/sss/pubconf/krb5.include.d/
     admin_server = {{ ipa_servers[0] }}:749
     default_domain = {{ client.domain }}
     pkinit_anchors = FILE:/etc/ipa/ca.crt
+    pkinit_pool = FILE:/etc/ipa/ca.crt
   }
 
 [domain_realm]
   .{{ client.domain }} = {{ client.realm }}
   {{ client.domain }} = {{ client.realm }}
-{%- if grains['fqdn'] in  ipa_servers %}
+{%- if grains['fqdn'] in ipa_servers %}
 
 [dbmodules]
-{{ client.realm }} = {
-  db_library = ipadb.so
-}
+  {{ client.realm }} = {
+    db_library = ipadb.so
+  }
 {%- endif %}
 
 {#-

--- a/freeipa/files/ldap.conf
+++ b/freeipa/files/ldap.conf
@@ -1,5 +1,6 @@
 {%- from "freeipa/map.jinja" import client, server, ipa_servers with context -%}
 
+SASL_NOCANON on
 TLS_CACERT /etc/ipa/ca.crt
 URI{% for server in ipa_servers %} ldaps://{{ server }}{% endfor %}
 {%- if client.get('enabled', False) %}

--- a/freeipa/files/named.conf
+++ b/freeipa/files/named.conf
@@ -12,9 +12,9 @@ options {
 
     forward {{ server.get('dns', {}).get('forward', 'first') }};
     forwarders { 
-            {%- for forwarder in server.get('dns', {}).get('forwarders', []) %}
-            {{ forwarder }};
-            {%- endfor %}
+        {%- for forwarder in server.get('dns', {}).get('forwarders', []) %}
+        {{ forwarder }};
+        {%- endfor %}
     };
 
     // Any host is permitted to issue recursive queries
@@ -60,7 +60,7 @@ include "/etc/named.root.key";
 
 dyndb "ipa" "/usr/lib64/bind/ldap.so" {
     uri "ldapi://%2fvar%2frun%2fslapd-{{ server.realm|replace('.', '-') }}.socket";
-    base "cn=dns, dc={{ server.realm|replace('.', '-') }}";
+    base "cn=dns, dc={{ server.domain|replace('.', ',dc=') }}";
     server_id "{{ hostname }}";
     auth_method "sasl";
     sasl_mech "GSSAPI";

--- a/freeipa/files/named.conf
+++ b/freeipa/files/named.conf
@@ -10,8 +10,12 @@ options {
     statistics-file     "data/named_stats.txt";
     memstatistics-file  "data/named_mem_stats.txt";
 
-    forward first;
-    forwarders { };
+    forward {{ server.get('dns', {}).get('forward', 'first') }};
+    forwarders { 
+            {%- for forwarder in server.get('dns', {}).get('forwarders', []) %}
+            {{ forwarder }};
+            {%- endfor %}
+    };
 
     // Any host is permitted to issue recursive queries
     allow-recursion { {{ server.get('dns', {}).get('recursion', 'localhost') }}; };
@@ -19,8 +23,8 @@ options {
     tkey-gssapi-keytab "/etc/named.keytab";
     pid-file "/run/named/named.pid";
 
-    dnssec-enable yes;
-    dnssec-validation yes;
+    dnssec-enable {% if server.get('dns', {}).get('dnssec', {}).get('enable', True) %}yes{% else %}no{% endif %};
+    dnssec-validation {% if server.get('dns', {}).get('dnssec', {}).get('validation', True) %}yes{% else %}no{% endif %};
 
     /* Path to ISC DLV key */
     bindkeys-file "/etc/named.iscdlv.key";
@@ -54,17 +58,14 @@ include "/etc/named.root.key";
 {%- set hostname = grains['fqdn'] %}
 {%- endif %}
 
-dynamic-db "ipa" {
-    library "ldap.so";
-    arg "uri ldapi://%2fvar%2frun%2fslapd-{{ server.realm|replace('.', '-') }}.socket";
-    arg "base cn=dns, dc={{ server.domain|replace('.', ',dc=') }}";
-    arg "fake_mname {{ hostname }}.";
-    arg "auth_method sasl";
-    arg "sasl_mech GSSAPI";
-    arg "sasl_user DNS/{{ hostname }}";
-    arg "serial_autoincrement yes";
+dyndb "ipa" "/usr/lib64/bind/ldap.so" {
+    uri "ldapi://%2fvar%2frun%2fslapd-{{ server.realm|replace('.', '-') }}.socket";
+    base "cn=dns, dc={{ server.domain|replace('.', ',dc=') }}";
+    server_id "{{ hostname }}";
+    auth_method "sasl";
+    sasl_mech "GSSAPI";
+    sasl_user "DNS/{{ hostname }}";
 };
-include "/etc/named.root.key";
 
 {%- for keyname, key in server.get('dns', {}).get('key', {}).iteritems() %}
 key "{{ keyname }}" {

--- a/freeipa/files/sssd.conf
+++ b/freeipa/files/sssd.conf
@@ -14,7 +14,11 @@ krb5_realm = {{ client.realm }}
 ipa_domain = {{ client.domain }}
 ipa_hostname = {{ client.get('hostname', grains['fqdn']) }}
 ipa_server = {{ '_srv_, ' if client.get('lookup', {}).get('kdc', False) else '' }}{{ ipa_servers|join(', ') }}
-ipa_dyndns_update = True
+{%- if pillar.freeipa.server is defined %}
+ipa_server_mode = True
+{%- else %}
+ipa_dyndns_update = {{ client.get('ipa_dyndns_update', True) }}
+{%- endif %}
 
 id_provider = ipa
 auth_provider = ipa
@@ -42,6 +46,8 @@ homedir_substring = /home
 [pac]
 
 [ifp]
+
+[secrets]
 
 {#-
 vim: syntax=jinja

--- a/freeipa/files/sssd.conf
+++ b/freeipa/files/sssd.conf
@@ -49,6 +49,8 @@ homedir_substring = /home
 
 [secrets]
 
+[session_recording]
+
 {#-
 vim: syntax=jinja
 -#}

--- a/freeipa/server/common.sls
+++ b/freeipa/server/common.sls
@@ -15,7 +15,7 @@ freeipa_server_pkgs:
   file.managed:
     - contents: {{ server.ldap.password }}
     - mode: 640
-    - owner: root
+    - user: root
     {%- if pillar.get('sensu', {}).get('client', {}).get('enabled', False) %}
     - group: sensu
     - require:
@@ -25,13 +25,15 @@ freeipa_server_pkgs:
 ldap_secure_binds:
   cmd.run:
     - name: |
-          ldapmodify -h localhost -D 'cn=directory manager' -w {{ server.ldap.password }} -Z << EOF
+          ldapmodify -h localhost -D 'cn=directory manager' -w "$FREEIPA_LDAP_PASSWORD" -Z << EOF
           dn: cn=config
           changetype: modify
           replace: nsslapd-minssf
           nsslapd-minssf: {{ server.ldap.minssf }}
           EOF
-    - unless: "ldapsearch -h localhost -D 'cn=directory manager' -w {{ server.ldap.password }} -b 'cn=config' -Z | grep 'nsslapd-minssf: {{ server.ldap.minssf }}'"
+    - env:
+      - FREEIPA_LDAP_PASSWORD: {{ server.ldap.password }}
+    - unless: "ldapsearch -h localhost -D 'cn=directory manager' -w \"$FREEIPA_LDAP_PASSWORD\" -b 'cn=config' -Z | grep 'nsslapd-minssf: {{ server.ldap.get('minssf', 0) }}'"
     - require:
       - cmd: freeipa_server_install
       - file: ldap_conf
@@ -40,13 +42,15 @@ ldap_secure_binds:
 ldap_logs_audit:
   cmd.run:
     - name: |
-          ldapmodify -h localhost -D 'cn=directory manager' -w {{ server.ldap.password }} -Z << EOF
+          ldapmodify -h localhost -D 'cn=directory manager' -w "$FREEIPA_LDAP_PASSWORD" -Z << EOF
           dn: cn=config
           changetype: modify
           replace: nsslapd-auditlog-logging-enabled
           nsslapd-auditlog-logging-enabled: {% if server.ldap.logging.audit %}on{% else %}off{% endif %}
           EOF
-    - unless: "ldapsearch -h localhost -D 'cn=directory manager' -w {{ server.ldap.password }} -b 'cn=config' -Z | grep 'nsslapd-auditlog-logging-enabled: {% if server.ldap.logging.audit %}on{% else %}off{% endif %}'"
+    - env:
+      - FREEIPA_LDAP_PASSWORD: {{ server.ldap.password }}
+    - unless: "ldapsearch -h localhost -D 'cn=directory manager' -w \"$FREEIPA_LDAP_PASSWORD\" -b 'cn=config' -Z | grep 'nsslapd-auditlog-logging-enabled: {% if server.ldap.logging.audit %}on{% else %}off{% endif %}'"
     - require:
       - cmd: freeipa_server_install
       - file: ldap_conf
@@ -56,13 +60,15 @@ ldap_logs_audit:
 ldap_logs_access:
   cmd.run:
     - name: |
-          ldapmodify -h localhost -D 'cn=directory manager' -w {{ server.ldap.password }} -Z << EOF
+          ldapmodify -h localhost -D 'cn=directory manager' -w "$FREEIPA_LDAP_PASSWORD" -Z << EOF
           dn: cn=config
           changetype: modify
           replace: nsslapd-accesslog-logging-enabled
           nsslapd-accesslog-logging-enabled: {% if server.ldap.logging.access %}on{% else %}off{% endif %}
           EOF
-    - unless: "ldapsearch -h localhost -D 'cn=directory manager' -w {{ server.ldap.password }} -b 'cn=config' -Z | grep 'nsslapd-accesslog-logging-enabled: {% if server.ldap.logging.access %}on{% else %}off{% endif %}'"
+    - env:
+      - FREEIPA_LDAP_PASSWORD: {{ server.ldap.password }}
+    - unless: "ldapsearch -h localhost -D 'cn=directory manager' -w \"$FREEIPA_LDAP_PASSWORD\" -b 'cn=config' -Z | grep 'nsslapd-accesslog-logging-enabled: {% if server.ldap.logging.access %}on{% else %}off{% endif %}'"
     - require:
       - cmd: freeipa_server_install
       - file: ldap_conf
@@ -72,13 +78,15 @@ ldap_logs_access:
 ldap_disable_anonymous:
   cmd.run:
     - name: |
-          ldapmodify -h localhost -D 'cn=directory manager' -w {{ server.ldap.password }} -Z << EOF
+          ldapmodify -h localhost -D 'cn=directory manager' -w "$FREEIPA_LDAP_PASSWORD" -Z << EOF
           dn: cn=config
           changetype: modify
           replace: nsslapd-allow-anonymous-access
           nsslapd-allow-anonymous-access: off
           EOF
-    - unless: "ldapsearch -h localhost -D 'cn=directory manager' -w {{ server.ldap.password }} -b 'cn=config' -Z | grep 'nsslapd-allow-anonymous-access: off'"
+    - env:
+      - FREEIPA_LDAP_PASSWORD: {{ server.ldap.password }}
+    - unless: "ldapsearch -h localhost -D 'cn=directory manager' -w \"$FREEIPA_LDAP_PASSWORD\" -b 'cn=config' -Z | grep 'nsslapd-allow-anonymous-access: off'"
     - require:
       - cmd: freeipa_server_install
       - file: ldap_conf

--- a/freeipa/server/master.sls
+++ b/freeipa/server/master.sls
@@ -11,17 +11,22 @@ freeipa_server_install:
         --realm {{ server.realm }}
         --domain {{ server.domain }}
         --hostname {% if server.hostname is defined %}{{ server.hostname }}{% else %}{{ grains['fqdn'] }}{% endif %}
-        --ds-password {{ server.ldap.password }}
-        --admin-password {{ server.admin.password }}
+        --ds-password "$FREEIPA_LDAP_PASSWORD"
+        --admin-password "$FREEIPA_ADMIN_PASSWORD"
         --ssh-trust-dns
         {%- if not server.get('ntp', {}).get('enabled', True) %} --no-ntp{%- endif %}
         {%- if server.get('dns', {}).get('zonemgr', False) %} --zonemgr {{ server.dns.zonemgr }}{%- endif %}
         {%- if server.get('dns', {}).get('enabled', True) %} --setup-dns{%- endif %}
+        --forward-policy={{ server.get('dns', {}).get('forward', 'first') }}
         {%- if server.get('dns', {}).get('forwarders', []) %}{%- for forwarder in server.dns.forwarders %} --forwarder={{ forwarder }}{%- endfor %}{%- else %} --no-forwarders{%- endif %}
+        {%- if not server.get('dns', {}).get('dnssec', {}).get('validation', True) %} --no-dnssec-validation{%- endif %}
         {%- if server.get('mkhomedir', True) %} --mkhomedir{%- endif %}
         --auto-reverse
         --no-host-dns
         --unattended
+    - env:
+      - FREEIPA_LDAP_PASSWORD: {{ server.ldap.password }}
+      - FREEIPA_ADMIN_PASSWORD: {{ server.admin.password }}
     - creates: /etc/ipa/default.conf
     - require:
       - pkg: freeipa_server_pkgs

--- a/freeipa/server/replica.sls
+++ b/freeipa/server/replica.sls
@@ -5,7 +5,7 @@ include:
 
 {#
  Replica needs to be prepared first on master using
-   ipa-replica-prepare ipareplica.example.com --ip-address 192.168.1.2 -p {{ server.ldap.password }}
+   ipa-replica-prepare ipareplica.example.com --ip-address 192.168.1.2 -p "$FREEIPA_LDAP_PASSWORD"
  and stored in /var/lib/ipa/replica-info-ipareplica.example.com.gpg
  #}
 
@@ -13,11 +13,13 @@ freeipa_server_install:
   cmd.run:
     - name: >
         ipa-replica-install
-        -w {{ server.admin.password }}
+        -w "$FREEIPA_ADMIN_PASSWORD"
         --ssh-trust-dns
         {%- if not server.get('ntp', {}).get('enabled', True) %} --no-ntp{%- endif %}
         {%- if server.get('dns', {}).get('enabled', True) %} --setup-dns{%- endif %}
+        --forward-policy={{ server.get('dns', {}).get('forward', 'first') }}
         {%- if server.get('dns', {}).get('forwarders', []) %}{%- for forwarder in server.dns.forwarders %} --forwarder={{ forwarder }}{%- endfor %}{%- else %} --no-forwarders{%- endif %}
+        {%- if not server.get('dns', {}).get('dnssec', {}).get('validation', True) %} --no-dnssec-validation{%- endif %}
         {%- if server.get('mkhomedir', True) %} --mkhomedir{%- endif %}
         {%- if server.get('no_host_dns', false) %} --no-host-dns{%- endif %}
         {%- if server.get('ca', true) %} --setup-ca{%- endif %}
@@ -29,11 +31,14 @@ freeipa_server_install:
         --domain {{ server.domain }}
         --realm {{ server.realm }}
         --server {{ server.servers.0 }}
-        --hostname {{ grains['fqdn'] }}
+        --hostname {{ server.get('hostname', grains['fqdn']) }}
         {%- else %}
-        --password {{ server.ldap.password }}
+        --password "$FREEIPA_LDAP_PASSWORD"
         /var/lib/ipa/replica-info-{{ server.get('hostname', grains['fqdn']) }}.gpg
         {%- endif %}
+    - env:
+      - FREEIPA_LDAP_PASSWORD: {{ server.ldap.password }}
+      - FREEIPA_ADMIN_PASSWORD: {{ server.admin.password }}
     - creates: /etc/ipa/default.conf
     - require:
       - pkg: freeipa_server_pkgs


### PR DESCRIPTION
Hello,

This pull request does three things.

1. Sends admin and ldap user credentials via environment variables to prevent them from showing up in the Salt master/minion logs.

2. Supports DNS forwarders without DNSSEC.  The use case is using the Amazon forwarders.

3. Updates named.conf to use the new _dyndb_ parameter which is used in the latest version of BIND.

Best,
Doug

