### PR TITLE
Provide some defaults to simplify user experience, formula usage & setup

### DIFF
--- a/freeipa/server/common.sls
+++ b/freeipa/server/common.sls
@@ -29,9 +29,9 @@ ldap_secure_binds:
           dn: cn=config
           changetype: modify
           replace: nsslapd-minssf
-          nsslapd-minssf: {{ salt['pillar.get']('server:ldap:minssf', 0) }}
+          nsslapd-minssf: {{ server.ldap.get('minssf', 0) }}
           EOF
-    - unless: "ldapsearch -h localhost -D 'cn=directory manager' -w {{ server.ldap.password }} -b 'cn=config' -Z | grep 'nsslapd-minssf: {{ salt['pillar.get']('server:ldap:minssf', 0) }}'"
+    - unless: "ldapsearch -h localhost -D 'cn=directory manager' -w {{ server.ldap.password }} -b 'cn=config' -Z | grep 'nsslapd-minssf: {{ server.ldap.get('minssf', 0) }}'"
     - require:
       - cmd: freeipa_server_install
       - file: ldap_conf
@@ -68,7 +68,7 @@ ldap_logs_access:
       - file: ldap_conf
 {%- endif %}
 
-{%- if server.ldap.anonymous is not defined %}
+{%- if not server.ldap.get('anonymous') %}
 ldap_disable_anonymous:
   cmd.run:
     - name: |

--- a/freeipa/server/common.sls
+++ b/freeipa/server/common.sls
@@ -29,9 +29,9 @@ ldap_secure_binds:
           dn: cn=config
           changetype: modify
           replace: nsslapd-minssf
-          nsslapd-minssf: {{ server.ldap.minssf }}
+          nsslapd-minssf: {{ salt['pillar.get']('server:ldap:minssf', 0) }}
           EOF
-    - unless: "ldapsearch -h localhost -D 'cn=directory manager' -w {{ server.ldap.password }} -b 'cn=config' -Z | grep 'nsslapd-minssf: {{ server.ldap.minssf }}'"
+    - unless: "ldapsearch -h localhost -D 'cn=directory manager' -w {{ server.ldap.password }} -b 'cn=config' -Z | grep 'nsslapd-minssf: {{ salt['pillar.get']('server:ldap:minssf', 0) }}'"
     - require:
       - cmd: freeipa_server_install
       - file: ldap_conf
@@ -68,7 +68,7 @@ ldap_logs_access:
       - file: ldap_conf
 {%- endif %}
 
-{%- if not server.ldap.anonymous %}
+{%- if server.ldap.anonymous is not defined %}
 ldap_disable_anonymous:
   cmd.run:
     - name: |

--- a/freeipa/server/master.sls
+++ b/freeipa/server/master.sls
@@ -12,7 +12,7 @@ freeipa_server_install:
         --domain {{ server.domain }}
         --hostname {% if server.hostname is defined %}{{ server.hostname }}{% else %}{{ grains['fqdn'] }}{% endif %}
         --ds-password {{ server.ldap.password }}
-        --admin-password {{ server.admin.password }}
+        --admin-password {{ salt['pillar.get']('server:admin:password', server.ldap.password) }}
         --ssh-trust-dns
         {%- if not server.get('ntp', {}).get('enabled', True) %} --no-ntp{%- endif %}
         {%- if server.get('dns', {}).get('zonemgr', False) %} --zonemgr {{ server.dns.zonemgr }}{%- endif %}

--- a/freeipa/server/master.sls
+++ b/freeipa/server/master.sls
@@ -12,7 +12,7 @@ freeipa_server_install:
         --domain {{ server.domain }}
         --hostname {% if server.hostname is defined %}{{ server.hostname }}{% else %}{{ grains['fqdn'] }}{% endif %}
         --ds-password {{ server.ldap.password }}
-        --admin-password {{ salt['pillar.get']('server:admin:password', server.ldap.password) }}
+        --admin-password {{ server.admin.get('password', server.ldap.password) }}
         --ssh-trust-dns
         {%- if not server.get('ntp', {}).get('enabled', True) %} --no-ntp{%- endif %}
         {%- if server.get('dns', {}).get('zonemgr', False) %} --zonemgr {{ server.dns.zonemgr }}{%- endif %}


### PR DESCRIPTION
This allows pillar.get to use defaults if minssf and an admin password are not supplied. minssf defaults to 0 which is the default used upstream by 389 server. This option is not in the examples in the README and we should provide a sane default to simplify the user experience. 

Secondly, the admin password defaults to the diradmin password with this change. I attempted having the ldap password default to the admin password, but the ldap portion of the pillar is used too frequently and must be defined. Having the admin password default to the diradmin password is the next best option.