### PR TITLE
[named.conf] Reverting back to fully qualified LDAP base string

### DIFF
--- a/freeipa/files/named.conf
+++ b/freeipa/files/named.conf
@@ -56,7 +56,7 @@ include "/etc/named.root.key";
 
 dyndb "ipa" "/usr/lib64/bind/ldap.so" {
         uri "ldapi://%2fvar%2frun%2fslapd-{{ server.realm|replace('.', '-') }}.socket";
-        base "cn=dns, dc={{ server.realm|replace('.', '-') }}";
+        base "cn=dns, dc={{ server.realm|replace('.', ',dc=') }}";
         server_id "{{ hostname }}";
         auth_method "sasl";
         sasl_mech "GSSAPI";


### PR DESCRIPTION
On a fresh FreeIPA server installation, `named` fails to fetch DNS zones from IPA due to a wrongly set base string. This seems to be due to a change in commit 43a02c0. 

This pull request reverts the change.