### PR TITLE
Fix support for salt 2019

### DIFF
--- a/freeipa/client/init.sls
+++ b/freeipa/client/init.sls
@@ -94,7 +94,7 @@ freeipa_kdestroy:
 
 freeipa_client_pkgs:
   pkg.installed:
-    - names: {{ client.pkgs }}
+    - names: {{ client.pkgs|tojson }}
 
 freeipa_client_install:
   cmd.run:

--- a/freeipa/server/common.sls
+++ b/freeipa/server/common.sls
@@ -9,7 +9,7 @@ include:
 
 freeipa_server_pkgs:
   pkg.installed:
-    - names: {{ server.pkgs }}
+    - names: {{ server.pkgs|tojson }}
 
 /etc/dirsrv/password:
   file.managed:


### PR DESCRIPTION
See https://docs.saltstack.com/en/latest/topics/releases/2019.2.0.html#non-backward-compatible-change-to-yaml-renderer

Signed-off-by: M. David Bennett <mdavidbennett@syntheticworks.com>