### PR TITLE
Let the user decide if they don't want to use the OpenSSH formula

### DIFF
--- a/freeipa/common.sls
+++ b/freeipa/common.sls
@@ -1,13 +1,17 @@
 {%- from "freeipa/map.jinja" import client,server with context %}
 
+{%- if not client.get('manual_sshd', False) %}
 include:
 - openssh.server
+{%- endif %}
 
 sssd_service:
   service.running:
     - name: sssd
+{%- if not client.get('manual_sshd', False) %}
     - watch_in:
       - service: openssh_server_service
+{%- endif %}
     - watch:
       - file: sssd_conf
 


### PR DESCRIPTION
I found the openssh formula to be very lacking in the configuration, so we can't use it with our policy requirements.
This lets us maintain OpenSSH configuration ourselves.