### PR TITLE
Use the servers list from the map

### DIFF
--- a/freeipa/client/init.sls
+++ b/freeipa/client/init.sls
@@ -100,7 +100,9 @@ freeipa_client_install:
   cmd.run:
     - name: >
         ipa-client-install
-        --server {{ client.server }}
+        {%- for server in ipa_servers %}
+        --server {{ server }}
+        {%- endfor %}
         --domain {{ client.domain }}
         {%- if client.realm is defined %} --realm {{ client.realm }}{%- endif %}
         --hostname {{ ipa_host }}


### PR DESCRIPTION
The `ipa_servers` list is already managed in the map, so there's no reason to not use it for everything.