### PR TITLE
Make chrony configuration optional for clients too

### DIFF
--- a/freeipa/client/init.sls
+++ b/freeipa/client/init.sls
@@ -109,6 +109,7 @@ freeipa_client_install:
         {%- else %}
         -w {{ client.otp }}
         {%- endif %}
+        {%- if not client.get('ntp', {}).get('enabled', True) %} --no-ntp{%- endif %}
         {%- if client.get('mkhomedir', True) %} --mkhomedir{%- endif %}
         {%- if client.dns.updates %} --enable-dns-updates{%- endif %}
         --unattended


### PR DESCRIPTION
We manage the NTP client ourselves, and prefer it if FreeIPA keeps its hands off.
The server configuration already has this option, this merely adds feature parity.