### PR TITLE
Add support for enrolling host with DNS records

### DIFF
--- a/freeipa/client/init.sls
+++ b/freeipa/client/init.sls
@@ -36,6 +36,8 @@ freeipa_dnsrecord_add:
         -H "Content-Type:application/json"
         -H "Accept:application/json"
         -c /tmp/cookiejar -b /tmp/cookiejar
+        --output /dev/stderr
+        --write-out "%{http_code}"
         -X POST
         -d '{
           "id": 0,
@@ -63,7 +65,7 @@ freeipa_dnsrecord_add:
               "version": "2.156"
             }
           ]
-        }' https://{{ ipa_servers[0] }}/ipa/json
+        }' https://{{ ipa_servers[0] }}/ipa/json | awk '{if ($0<200||$0>399) exit $0}'
     - require:
       - cmd: freeipa_get_ticket
     - require_in:
@@ -80,6 +82,8 @@ freeipa_host_add:
         -H "Content-Type:application/json"
         -H "Accept:applicaton/json"
         -c /tmp/cookiejar -b /tmp/cookiejar
+        --output /dev/stderr
+        --write-out "%{http_code}"
         -X POST
         -d '{
           "id": 0,
@@ -99,7 +103,7 @@ freeipa_host_add:
               "version": "2.156"
             }
           ]
-        }' https://{{ ipa_servers[0] }}/ipa/json
+        }' https://{{ ipa_servers[0] }}/ipa/json | awk '{if ($0<200||$0>399) exit $0}'
     - require:
       - cmd: freeipa_get_ticket
 {%- if client.ip is defined %}


### PR DESCRIPTION
This resolves #17, both issue 1 and issue 2.

I would have prefered to use [salt.states.http](https://docs.saltproject.io/en/latest/ref/states/all/salt.states.http.html) for this, as I mentioned in #17, but it has no support for GSSAPI/Kerberos authentication.

The awk hack was necessary because curl has no support for exiting on failures _with output_ [until v7.76.0](https://github.com/curl/curl/pull/6449), which is way too recent for most systems right now.

Sample usage from pillar definition, using the first example from the readme:
```yaml
freeipa:
  client:
    enabled: true
    server: ipa.example.com
    domain: {{ salt['grains.get']('domain', '') }}
    realm: {{ salt['grains.get']('domain', '').upper() }}
    hostname: {{ salt['grains.get']('fqdn', '') }}
    ip:
      reverse: true # defaults to true
      a: {{ salt.grains.get('fqdn_ip4', [])[0] }}
```

I tested this on Rocky Linux 8.4 with FreeIPA 4.9.2.